### PR TITLE
fixing surface width calculation using pitch instead of width and using font.ttf in binary dir instead

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -320,7 +320,7 @@ int main(int argc, char* argv[]) {
 	glEnable(GL_DEPTH_TEST);
 
 	// Load font
-	View::setFont("/usr/share/fonts/truetype/DejaVuSans.ttf", 16);	// ick - seems there is no search.
+	View::setFont("font.ttf", 12);	// ick - seems there is no search.
 
 	// Set up views
 	createViews();

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -59,9 +59,9 @@ void View::setText(const char* text) {
 		SDL_Colour colour;
 		colour.r = colour.g = colour.b = /*colour.a =*/ 255;
 		SDL_Surface* s = TTF_RenderText_Blended(staticFont, text, colour);
-		m_textWidth  = s->w;
+		m_textWidth  = s->pitch/4;
 		m_textHeight = s->h;
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, s->w, s->h, 0, GL_BGRA, GL_UNSIGNED_BYTE, s->pixels);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, s->pitch/4, s->h, 0, GL_BGRA, GL_UNSIGNED_BYTE, s->pixels);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		SDL_FreeSurface(s);


### PR DESCRIPTION
fixing surface width calculation using pitch instead of width and using font.ttf in binary dir instead